### PR TITLE
add onretryablefailure and fix broken json

### DIFF
--- a/Logstash.groovy
+++ b/Logstash.groovy
@@ -17,7 +17,13 @@ def sendNotification(Map execution, Map config) {
 
   // Execution Information
   def e2 = [:]
-  execution.each{ e2["${it.key}"] = it.value }
+  execution.each{
+    if ("${it.key}" == "argstring" && it.value != null) {
+      e2["${it.key}"] = "${it.value}".replaceAll("\"", "'")
+    } else {
+      e2["${it.key}"] = it.value
+    }
+  }
 
   // Stream
   def json = new ObjectMapper()

--- a/Logstash.groovy
+++ b/Logstash.groovy
@@ -51,4 +51,9 @@ rundeckPlugin(NotificationPlugin) {
     sendNotification(executionData, configuration)
     true
   }
+
+  onretryablefailure { Map executionData, Map configuration ->
+    sendNotification(executionData, configuration)
+    true
+  }
 }


### PR DESCRIPTION
When we have spaces in an option, Rundeck adds double quotes to the options in the argstring value and it broke the JSON format. So, I replace double quotes to simple quotes.